### PR TITLE
Macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ tinymt32.o: tinymt/tinymt32.c
 tinymt64.o: tinymt/tinymt64.c
 	$(CC) $(CFLAGS) $^ -c -o $@
 
-test: libexport.so libtinymt.so
+test: libexport.$(dyn) libtinymt.$(dyn)
 	terra import.t
 	terra test_random.t
 

--- a/random.t
+++ b/random.t
@@ -4,6 +4,18 @@ local C = terralib.includecstring[[
   #include <stdlib.h>
   #include "tinymt/tinymt64.h"
 ]]
+-- terra does not import macros other than those that set a constant number
+-- this causes an issue on macos, where 'stderr', etc are defined by referencing
+-- to another implementation in a file. So we set them here. 
+if rawget(C,"stderr")==nil and rawget(C,"__stderrp")~=nil then
+    rawset(C,"stderr",C.__stderrp)
+end
+if rawget(C,"stdin")==nil and rawget(C,"__stdinp")~=nil then
+    rawset(C,"stdin",C.__stdinp)
+end 
+if rawget(C,"stdout")==nil and rawget(C,"__stdoutp")~=nil then
+    rawset(C,"stdout",C.__stdoutp)
+end 
 
 local uname = io.popen("uname","r"):read("*a")
 if uname == "Darwin\n" then


### PR DESCRIPTION
Fixed one issue in the Makefile, and added a temporary workaround in random.t to provide access to C.stderr. The issue here is that terra does not include C macro's that are not a number. We need to decide what to do about this later.