### PR TITLE
Terraform - access to concrete types via template parameters

### DIFF
--- a/matrix_blas_dense.t
+++ b/matrix_blas_dense.t
@@ -35,8 +35,8 @@ local function BLASDenseMatrixBase(M)
             where {T1 : BLASNumber, V1 : BLASVector, T2 : BLASNumber, V2 : BLASVector}
         escape
             local T = M.eltype
-            assert(T == x.type.type.eltype)
-            assert(T == y.type.type.eltype)
+            assert(T == V1.eltype)
+            assert(T == V2.eltype)
         end
         var nx, xptr, incx = x:getblasinfo()
         var ny, yptr, incy = y:getblasinfo()
@@ -61,8 +61,8 @@ local function BLASDenseMatrixBase(M)
             where {S1 : BLASNumber, S2 : BLASNumber, M1 : BLASDenseMatrix, M2 : BLASDenseMatrix}
         escape
             local T = M.eltype
-            assert(T == a.type.type.eltype)
-            assert(T == b.type.type.eltype)
+            assert(T == M1.eltype)
+            assert(T == M2.eltype)
         end
         var nc, mc, ptrc, ldc = self:getblasdenseinfo()
         var na, ma, ptra, lda = a:getblasdenseinfo()

--- a/terraform.t
+++ b/terraform.t
@@ -70,6 +70,14 @@ function parse_terraform_statement(self,lex)
 	return templ
 end
 
+--dereference n times
+local function dref(t, n)
+	for i = 1, n do
+		t = t.type
+	end
+	return t
+end
+
 function generate_terrafun(templ, localenv)
 	return function(...)
 		local types = terralib.newlist{...}
@@ -87,8 +95,13 @@ function generate_terrafun(templ, localenv)
 			end
 			local sym = symbol(argtype)
 			argumentlist:insert(sym)
-			--add variable and its type to the local environment
+			--add variable to the local environment
 			localenv[param.name] = sym
+			--add parametric type parameter to the local environment
+			if templ.constraints[param.typename] then
+				--we are dealing with a parametric type
+				localenv[param.typename] = dref(argtype, param.nref)
+			end
 		end
 		return terra([argumentlist])
 			[templ.terrastmts(localenv)]

--- a/test_terraform.t
+++ b/test_terraform.t
@@ -16,6 +16,7 @@ local Integer = concept.Integer
 local Float = concept.Float
 local size_t = uint64
 
+
 testenv "terraforming free functions" do
 
     testset "concrete types" do
@@ -233,7 +234,7 @@ testenv "terraforming free functions" do
     testset "Access to parametric types in escape" do
         terraform foo(a : T1, b : T2) where {T1 : Float, T2 : Float}
             escape
-                assert(a.type == double and b.type==float)
+                assert(T1 == double and T2 == float)
             end
             return a * b + 1
         end


### PR DESCRIPTION
You can not get access to the type to by the template parameter

```
terraform foo(a : T1, b : T2) where {T1 : Float, T2 : Float}
    escape
        assert(T1 == double and T2 == float)
    end
    return a * b + 1
end
assert(foo(2.0, float(3.0)) == 7)
```