### PR TITLE
Numbers - unit, zero, eps, numtostr

### DIFF
--- a/complex.t
+++ b/complex.t
@@ -93,7 +93,8 @@ local complex = terralib.memoize(function(T)
     end
 
     --maxlen is twice the size of T and twice one char for the sign
-    local maxlen = 2 * tmath.ndigits(sizeof(T)) + 2
+    --+1 for /0 terminating character
+    local maxlen = 2 * tmath.ndigits(sizeof(T)) + 2 + 1
     terra complex:tostr()
         var buffer : int8[maxlen]
         var re, im =  self:real(), self:imag()

--- a/complex.t
+++ b/complex.t
@@ -100,10 +100,10 @@ local complex = terralib.memoize(function(T)
         if im < 0 then
             im = -im
             var s1, s2 = tmath.numtostr(re), tmath.numtostr(im)
-            var j = C.snprintf(buffer, maxlen, "%s-%sim", s1, s2)
+            C.snprintf(buffer, maxlen, "%s-%sim", s1, s2)
         else
             var s1, s2 = tmath.numtostr(re), tmath.numtostr(im)
-            var j = C.snprintf(buffer, maxlen, "%s+%sim", s1, s2)
+            C.snprintf(buffer, maxlen, "%s+%sim", s1, s2)
         end
         return buffer
     end

--- a/complex.t
+++ b/complex.t
@@ -10,6 +10,8 @@ local C = terralib.includecstring[[
     #include <math.h>
 ]]
 
+import "terraform"
+
 local base = require("base")
 local concepts = require("concepts")
 local tmath = require("mathfuns")
@@ -108,7 +110,10 @@ local complex = terralib.memoize(function(T)
         end
         return str
     end
-    tmath.numtostr:adddefinition(terra(x : complex) return x:tostr() end)
+
+    terraform tmath.numtostr(x : complex) 
+        return x:tostr() 
+    end
 
     terra complex:inverse()
        var nrmsq = self:normsq()

--- a/mathfuns.t
+++ b/mathfuns.t
@@ -157,11 +157,7 @@ for _, name in pairs({"real", "imag", "conj"}) do
     end
 end
 
---determine the mximum number of digits in representing a number of
---n bytes. here we use:
---log10(2) \approx 0.31
---+1 for a possible sign
---ceil to be on the safe side
+--determine the number of digits in representing a number of n bytes.
 tmath.ndigits = function(nbytes)
     return math.ceil(8 * nbytes * (math.log(2) / math.log(10)))
 end
@@ -185,7 +181,7 @@ for _,T in ipairs{float, double, int8, int16, int32, int64, uint8, uint16, uint3
     numtostr:adddefinition(
         terra(v : T)
             var buffer : int8[maxlen]
-            var j = C.snprintf(buffer, maxlen, format, v)
+            C.snprintf(buffer, maxlen, format, v)
             return buffer
         end
     )

--- a/mathfuns.t
+++ b/mathfuns.t
@@ -175,8 +175,11 @@ for _,T in ipairs{float, double, int8, int16, int32, int64, uint8, uint16, uint3
     else
         error("Please specify a format for this type.")
     end
-    --length of static buffer and format
-    local maxlen = tmath.ndigits(sizeof(T))
+    --length of static buffer
+    --+1 for sign
+    --+1 for /0 terminating character
+    local maxlen = tmath.ndigits(sizeof(T)) + 1 + 1
+    --format of number type T
     local format = numtostr.format[T]
     numtostr:adddefinition(
         terra(v : T)

--- a/mathfuns.t
+++ b/mathfuns.t
@@ -159,6 +159,14 @@ end
 
 --numbers to string
 math.numtostr = terralib.overloadedfunction("numtostr")
+for _, T in ipairs{uint8, uint16, uint32, uint64} do
+    local impl = terra(v : T)
+        var str : int8[8]
+        C.sprintf(&str[0], "%u", v)
+        return str
+    end
+    math.numtostr:adddefinition(impl)
+end
 for _, T in ipairs{int8, int16, int32, int64} do
     local impl = terra(v : T)
         var str : int8[8]

--- a/mathfuns.t
+++ b/mathfuns.t
@@ -7,6 +7,7 @@ import "terraform"
 
 local math = {}
 local C = terralib.includecstring[[
+    #include <stdio.h>
     #include <stdlib.h>
     #include <math.h>
     #include <tgmath.h>
@@ -15,8 +16,17 @@ local concepts = require("concepts")
 --constants
 math.pi = constant(3.14159265358979323846264338327950288419716939937510)
 
-function float:eps() return 0x1p-23 end
-function double:eps() return 0x1p-52 end
+function float:eps() return constant(float, 0x1p-23) end
+function double:eps() return constant(double, 0x1p-52) end
+
+for _,T in ipairs({float, double, int8, int16, int32, int64, uint8, uint16, uint32, uint64}) do
+    function T:zero()
+        return constant(T, 0)
+    end
+    function T:unit()
+        return constant(T, 1)
+    end
+end
 
 local funs_single_var = {
     sin = "sin",
@@ -145,6 +155,25 @@ for _, name in pairs({"real", "imag", "conj"}) do
         end
         math[name]:adddefinition(impl)
     end
+end
+
+--numbers to string
+math.numtostr = terralib.overloadedfunction("numtostr")
+for _, T in ipairs{int8, int16, int32, int64} do
+    local impl = terra(v : T)
+        var str : int8[8]
+        C.sprintf(&str[0], "%d", v)
+        return str
+    end
+    math.numtostr:adddefinition(impl)
+end
+for _, T in ipairs{float, double} do
+    local impl = terra(v : T)
+        var str : int8[8]
+        C.sprintf(&str[0], "%0.3f", v)
+        return str
+    end
+    math.numtostr:adddefinition(impl)
 end
 
 return math

--- a/nfloat.t
+++ b/nfloat.t
@@ -124,6 +124,14 @@ local FixedFloat = terralib.memoize(function(N)
     --  d[0]
     --   ...
     --  d[M-1]
+    --here d[M-1] is the significant part of the mantissa, which means that 
+    --it encodes the first 64 bits of the floating point number. This is used
+    --for example in truncation to a dpouble value.
+    --
+    --Note that the order of the mantissa is non-intuitive. The order is reversed
+    --as compared to how integers are typically stored. That's why bit shofting 
+    --1 << 63 is needed in the following example 
+    --
     --example: N = 128, M = 2, representing the value 1
     --x.data.head[0] = 1
     --x.data.head[1] = 0
@@ -157,6 +165,9 @@ local FixedFloat = terralib.memoize(function(N)
         for i = 1, M do
             d[i] = 0ULL
         end
+        --the order of the mantissa is opposite to how an integer is
+        --typically stored in memory. That's why we need to shift 63 
+        --bits to the left.
         local bitshiftone = bit.lshift(1ULL, 63)
         if value == 0 then
             return {{bitshiftone, 0ULL}, d}
@@ -324,7 +335,7 @@ local FixedFloat = terralib.memoize(function(N)
     tmath.numtostr:adddefinition(
         terra(v : nfloat)
             var buffer : int8[maxlen]
-            var j = C.snprintf(buffer, maxlen, format, v:truncatetodouble())
+            C.snprintf(buffer, maxlen, format, v:truncatetodouble())
             return buffer
         end
     )

--- a/nfloat.t
+++ b/nfloat.t
@@ -164,14 +164,18 @@ local FixedFloat = terralib.memoize(function(N)
         end
     end
     
-    local zero = constant(terralib.new(nfloat, {terralib.new(ctype, genfloat(0))}))
-    local unit = constant(terralib.new(nfloat, {terralib.new(ctype, genfloat(1))}))
-    local eps = constant(terralib.new(nfloat, {terralib.new(ctype, genfloat("eps"))}))
+    local zero = terralib.new(nfloat, {terralib.new(ctype, genfloat(0))})
+    local unit = terralib.new(nfloat, {terralib.new(ctype, genfloat(1))})
+    local eps = terralib.new(nfloat, {terralib.new(ctype, genfloat("eps"))})
     
-    function nfloat:zero() return zero end
-    function nfloat:unit() return unit end
+    function nfloat:__newzero() return zero end
+    function nfloat:__newunit() return unit end
+    function nfloat:__neweps() return eps end
+
+    function nfloat:zero() return constant(zero) end
+    function nfloat:unit() return constant(unit) end
     --distance from 1.0 to next floating point value
-    function nfloat:eps() return eps end
+    function nfloat:eps() return constant(eps) end
 
     local terra new()
         var data: ctype

--- a/nfloat.t
+++ b/nfloat.t
@@ -331,7 +331,10 @@ local FixedFloat = terralib.memoize(function(N)
     --for now we format up to double precision.
     --ToDo: specialized print.
     local format = global(rawstring, "%0.2f")
-    local maxlen = tmath.ndigits(sizeof(double))
+    --length of static buffer
+    --+1 for sign
+    --+1 for /0 terminating character
+    local maxlen = tmath.ndigits(sizeof(double)) + 1 + 1
     tmath.numtostr:adddefinition(
         terra(v : nfloat)
             var buffer : int8[maxlen]

--- a/nfloat.t
+++ b/nfloat.t
@@ -18,6 +18,8 @@ else
     error("Not implemented for this OS.")
 end
 
+import "terraform"
+
 local base = require("base")
 local tmath = require("mathfuns")
 local concepts = require("concepts")
@@ -111,7 +113,7 @@ local FixedFloat = terralib.memoize(function(N)
     --local M = N / 64
     --struct float_type
     --  head : uint64[2]
-    --  d : uint64[M-1]
+    --  d : uint64[M]
     --end
     --here the 'head' stores the exponent and sign
     --  head[0] --exponent
@@ -153,13 +155,14 @@ local FixedFloat = terralib.memoize(function(N)
         for i = 1, M do
             d[i] = 0ULL
         end
+        local bitshiftone = bit.lshift(1ULL, 63)
         if value == 0 then
-            return {{9223372036854775808ULL, 0ULL}, d}
+            return {{bitshiftone, 0ULL}, d}
         elseif value == 1 then
-            d[M] = 9223372036854775808ULL
+            d[M] = bitshiftone
             return {{1ULL, 0ULL}, d}
         elseif value == "eps" then
-            d[M] = 9223372036854775808ULL
+            d[M] = bitshiftone
             return {{-N, 0ULL}, d}
         end
     end
@@ -312,9 +315,9 @@ local FixedFloat = terralib.memoize(function(N)
         return s * shiftandscale(m, e)
     end
 
-    tmath.numtostr:adddefinition(terra(v : nfloat)
+    terraform tmath.numtostr(v : nfloat)
         return tmath.numtostr(v:truncatetodouble())
-    end)
+    end
 
     for _, func in pairs(unary_math) do
         local name = "nfloat_" .. func

--- a/template.t
+++ b/template.t
@@ -314,15 +314,15 @@ function Template:new()
 
 	function template:adddefinition(methods)
 		methods = methods or {}
-		for sig,func in pairs(methods) do
+		for sig, func in pairs(methods) do
 			--check if method with this serialized key already exists
 			for s,v in pairs(self.methods) do
 				if sig:serialize()==s:serialize() then --overwrite old definition
-					self.methods[s] = func
+					self.methods[s] = terralib.memoize(func)
 					return
 				end
 			end
-			self.methods[sig] = func
+			self.methods[sig] = terralib.memoize(func)
         end
     end
 
@@ -376,18 +376,7 @@ local functiontemplate = function(name, methods)
 
     local t = constant(T)
     function t:adddefinition(methods)
-		methods = methods or {}
-        for sig, func in pairs(methods) do
-			--check if method with this serialized key already exists
-			for s,v in pairs(T.templates.eval.methods) do
-				if sig:serialize()==s:serialize() then --overwrite old definition
-					T.templates.eval:adddefinition{[s] = func}
-					return
-				end
-			end
-			--otherwise add new definition with new key
-			T.templates.eval:adddefinition{[sig] = func}
-        end
+		T.templates.eval:adddefinition(methods)
     end
     function t:dispatch(...)
 		local sig, func = dispatch(T, ...)

--- a/template.t
+++ b/template.t
@@ -315,14 +315,15 @@ function Template:new()
 	function template:adddefinition(methods)
 		methods = methods or {}
 		for sig, func in pairs(methods) do
+			func = terralib.memoize(func)
 			--check if method with this serialized key already exists
 			for s,v in pairs(self.methods) do
 				if sig:serialize()==s:serialize() then --overwrite old definition
-					self.methods[s] = terralib.memoize(func)
+					self.methods[s] = func
 					return
 				end
 			end
-			self.methods[sig] = terralib.memoize(func)
+			self.methods[sig] = func
         end
     end
 

--- a/terraform.t
+++ b/terraform.t
@@ -157,7 +157,7 @@ function process_free_function_statement(templ)
 		--get/register new template function
 		local templfun = localenv[templ.path] or template.functiontemplate(templ.methodname)
 		--add current template method implementation
-		templfun:adddefinition({[paramconceptlist] = terralib.memoize(generate_terrafun(templ,localenv))})
+		templfun:adddefinition({[paramconceptlist] = generate_terrafun(templ,localenv)})
 		return templfun
 	end
 end
@@ -180,7 +180,7 @@ function process_namespaced_function_statement(templ)
 			templfun = localenv[templ.path] or template.functiontemplate(templ.methodname)
 		end
 		--add current template method implementation
-		templfun:adddefinition({[paramconceptlist] = terralib.memoize(generate_terrafun(templ,localenv))})
+		templfun:adddefinition({[paramconceptlist] = generate_terrafun(templ,localenv)})
 		--register method
 		if isstaticmethod(templ,localenv) then
 			local class = localenv(templ.path,1)
@@ -203,7 +203,7 @@ function process_class_method_statement(templ)
 		if not class["templates"] then base.AbstractBase(class) end --add base functionality
 		local templfun = class["templates"][templ.methodname] or template.Template:new(templ.methodname)
 		--add current template method implementation
-		templfun:adddefinition({[paramconceptlist] = terralib.memoize(generate_terrafun(templ,localenv))})
+		templfun:adddefinition({[paramconceptlist] = generate_terrafun(templ,localenv)})
 		--register class method
 		class["templates"][templ.methodname] = templfun
 	end
@@ -221,7 +221,7 @@ function process_concept_statement(templ)
 			--get/register new template function
 			local templfun = localenv[templ.path] or concepts.para.parametrizedconcept(templ.methodname)
 			--add current template method implementation
-			templfun:adddefinition({[paramconceptlist] = terralib.memoize(generate_luafun(templ, localenv))})
+			templfun:adddefinition({[paramconceptlist] = generate_luafun(templ, localenv)})
 			--return parameterized concept
 			return templfun
 		--if a true concept then

--- a/test_blas.t
+++ b/test_blas.t
@@ -22,8 +22,8 @@ local types = {
 local unit = {
 	["s"] = `float(0),
 	["d"] = `double(0),
-	["c"] = `complexFloat.I(),
-	["z"] = `complexDouble.I()}
+	["c"] = `[complexFloat:unit()],
+	["z"] = `[complexDouble:unit()]}
 
 import "terratest/terratest"
 

--- a/test_cholesky.t
+++ b/test_cholesky.t
@@ -26,7 +26,7 @@ local io = terralib.includec("stdio.h")
 for _, Ts in pairs({float, double, float128, float1024}) do
     for _, is_complex in pairs({false, true}) do
         local T = is_complex and complex.complex(Ts) or Ts
-        local unit = is_complex and quote in T.unit() end or quote in 0 end
+        local unit = is_complex and T:unit() or 0 
         local DMat = dmatrix.DynamicMatrix(T)
         local DVec = dvector.DynamicVector(T)
         local Alloc = alloc.DefaultAllocator(Ts)

--- a/test_complex.t
+++ b/test_complex.t
@@ -12,6 +12,26 @@ local nfloat = require("nfloat")
 
 local float256 = nfloat.FixedFloat(256)
 
+if not __silent__ then
+
+    --some printing tests
+    local complex_t = complex.complex(double)
+    local format = tmath.numtostr.format[double]
+    terra main()
+		var x = complex_t.from(1, 2)
+		var y = complex_t.from(1, -2)
+		
+        io.printf("x = %s\n", tmath.numtostr(x))
+		io.printf("y = %s\n", tmath.numtostr(y))
+
+        format = "%0.3e"
+        io.printf("value = %s\n", tmath.numtostr(x))
+		io.printf("value = %s\n", tmath.numtostr(y))
+    end
+    main()
+
+end
+
 
 
 testenv "Complex numbers" do

--- a/test_complex.t
+++ b/test_complex.t
@@ -5,22 +5,32 @@
 
 import "terratest/terratest"
 
+local io = terralib.includec("stdio.h")
+local tmath = require("mathfuns")
 local complex = require("complex")
+local nfloat = require("nfloat")
+
+local float256 = nfloat.FixedFloat(256)
+
+
 
 testenv "Complex numbers" do
-	for _, T in pairs({float, double, int8, int16, int32, int64}) do
-		local complex = complex.complex(T)
+	for _, T in pairs({float, double, float256, int8, int16, int32, int64}) do
+		
+		local complex_t = complex.complex(T)
+		local im = complex_t:unit()
+
 		testset(T) "Initialization" do
 			terracode
-				var x = complex.from(1, 2) 
-				var y = 1 + 2 * complex.I()
+				var x = complex_t.from(1, 2) 
+				var y = 1 + 2 * im
 			end
 			test x == y
 		end
 
 		testset(T) "Copy" do
 			terracode
-				var x = 2 + 3 * complex.I()
+				var x = 2 + 3 * im
 				var y = x
 			end
 			test x == y
@@ -29,41 +39,41 @@ testenv "Complex numbers" do
 		testset(T) "Cast" do
 			terracode
 				var x: T = 2
-				var y: complex = x
-				var xc = complex.from(x, 0)
+				var y: complex_t = x
+				var xc = complex_t.from(x, 0)
 			end
 			test y == xc
 		end
 
 		testset(T) "Add" do
 			terracode
-				var x = 1 + 1 * complex.I()
-				var y = 2 + 3 * complex.I()
-				var z = 3 + 4 * complex.I()
+				var x = 1 + 1 * im
+				var y = 2 + 3 * im
+				var z = 3 + 4 * im
 			end
 			test x + y == z
 		end
 
 		testset(T) "Mul" do
 			terracode
-				var x = -1 + complex.I()
-				var y = 2 - 3 * complex.I()
-				var z = 1 + 5 * complex.I()
+				var x = -1 + im
+				var y = 2 - 3 * im
+				var z = 1 + 5 * im
 			end
 			test x * y == z
 		end
 
 		testset(T) "Neg" do
 			terracode
-				var x = -1 + 2 * complex.I()
-				var y = 1 - 2 * complex.I()
+				var x = -1 + 2 * im
+				var y = 1 - 2 * im
 			end
 			test x == -y
 		end
 
 		testset(T) "Normsq" do
 			terracode
-				var x = 3 + 4 * complex.I()
+				var x = 3 + 4 * im
 				var y = 25
 			end
 			test x:normsq() == y
@@ -71,7 +81,7 @@ testenv "Complex numbers" do
 
 		testset(T) "Real and imaginary parts" do
 			terracode
-				var x = -3 + 5 * complex.I()
+				var x = -3 + 5 * im
 				var xre = -3
 				var xim = 5
 			end
@@ -81,8 +91,8 @@ testenv "Complex numbers" do
 
 		testset(T) "Conj" do
 			terracode
-				var x = 5 - 3 * complex.I()
-				var xc = 5 + 3 * complex.I()
+				var x = 5 - 3 * im
+				var xc = 5 + 3 * im
 			end
 			test x:conj() == xc
 		end
@@ -90,8 +100,8 @@ testenv "Complex numbers" do
 		if T:isfloat() then
 			testset(T) "Inverse" do
 				terracode
-					var x = -3 + 5 * complex.I()
-					var y = -[T](3) / 34 - [T](5) / 34 * complex.I()
+					var x = -3 + 5 * im
+					var y = -[T](3) / 34 - [T](5) / 34 * im
 				end
 				test x:inverse() == y
 			end
@@ -99,9 +109,9 @@ testenv "Complex numbers" do
 
 		testset(T) "Sub" do
 			terracode
-				var x = 2 - 3 * complex.I()
-				var y = 5 + 4 * complex.I()
-				var z = - 3 - 7 * complex.I()
+				var x = 2 - 3 * im
+				var y = 5 + 4 * im
+				var z = - 3 - 7 * im
 			end
 			test x - y == z
 		end
@@ -109,9 +119,9 @@ testenv "Complex numbers" do
 		if T:isfloat() then
 			testset(T) "Div" do
 				terracode
-					var x = -5 + complex.I()
-					var y = 1 + complex.I()
-					var z = -2 + 3 * complex.I()
+					var x = -5 + im
+					var y = 1 + im
+					var z = -2 + 3 * im
 				end
 				test x / y == z
 			end
@@ -119,10 +129,10 @@ testenv "Complex numbers" do
 
 		testset(T) "Unit" do
 			terracode
-				var u = complex.from(0, 1)
+				var u = complex_t.from(0, 1)
 			end
-			test u == complex.I()
-			test u == complex.unit()
+			test u == im
+			test u == [complex_t:unit()]
 		end
 	end
 end

--- a/test_dmatrix.t
+++ b/test_dmatrix.t
@@ -206,7 +206,7 @@ for _, T in pairs({double, float, int64, cdouble, cfloat, cint, float128, cfloat
             testset "Mul complex" do
                 terracode
                     var alloc: DefaultAlloc
-                    var I = T.unit()
+                    var I = [T:unit()]
                     var a = Mat.from(&alloc, {{1 + 4 * I, 2 + 3 * I}, {3 + 2 * I, 4 + I}})
                     var b = Mat.from(&alloc, {{2, -1 - I}, {-1 + I, 2}})
                     var c = Mat.zeros_like(&alloc, &a)

--- a/test_lapack.t
+++ b/test_lapack.t
@@ -22,8 +22,8 @@ local types = {
 local unit = {
     ["s"] = `float(0),
     ["d"] = `double(0),
-    ["c"] = `complexFloat.I(),
-    ["z"] = `complexDouble.I(),
+    ["c"] = `[complexFloat:unit()],
+    ["z"] = `[complexDouble:unit()],
 }
 
 local tol = {

--- a/test_lu.t
+++ b/test_lu.t
@@ -26,7 +26,7 @@ local tol = {["float"] = 1e-6,
 for _, Ts in pairs({float, double, float128, float1024}) do
     for _, is_complex in pairs({false, true}) do
         local T = is_complex and complex.complex(Ts) or Ts
-        local unit = is_complex and quote in T.unit() end or quote in 0 end
+        local unit = is_complex and T:unit() or 0
         local DMat = dmatrix.DynamicMatrix(T)
         local DVec = dvector.DynamicVector(T)
         local PVec = dvector.DynamicVector(int32)

--- a/test_math.t
+++ b/test_math.t
@@ -7,22 +7,7 @@ import "terratest/terratest"
 
 local tmath = require('mathfuns')
 local io = terralib.includec("stdio.h")
-
-if not __silent__ then
-
-    --some printing tests
-    local format = tmath.numtostr.format[double]
-    terra main()
-        io.printf("value = %s\n", tmath.numtostr(1))
-        io.printf("value = %s\n", tmath.numtostr(1.999999999999))
-
-        format = "%0.3e"
-        io.printf("value = %s\n", tmath.numtostr(1))
-        io.printf("value = %s\n", tmath.numtostr(1.999999999999))
-    end
-    main()
-
-end
+local C = terralib.includec("string.h")
 
 local funs_single_var = {
     "sin",
@@ -74,6 +59,21 @@ testenv "Correctness of selected math functions" do
         test tmath.isapprox(tmath.pi, [math.pi], 1e-15) --compare with Lua's value
         test [float:eps()] == 0x1p-23
         test [double:eps()] == 0x1p-52
+    end
+
+    testset "printing" do
+        --some printing tests
+        local format = tmath.numtostr.format[double]
+        terracode
+            format = "%0.2f"
+            var s1 = tmath.numtostr(1)
+            var s2 = tmath.numtostr(1.999999999999)
+            format = "%0.3e"
+            var s3 = tmath.numtostr(1.999999999999)
+        end
+        test C.strcmp(&s1[0], "1") == 0
+        test C.strcmp(&s2[0], "2.00") == 0
+        test C.strcmp(&s3[0], "2.000e+00") == 0
     end
 
     testset "sqrt" do

--- a/test_math.t
+++ b/test_math.t
@@ -6,6 +6,7 @@
 import "terratest/terratest"
 
 local tmath = require('mathfuns')
+local io = terralib.includec("stdio.h")
 
 local funs_single_var = {
     "sin",
@@ -77,6 +78,19 @@ testenv "Correctness of selected math functions" do
     testset "cos" do
         test tmath.isapprox(tmath.cos([float](tmath.pi)), -1, 1e-7f) 
         test tmath.isapprox(tmath.cos([double](tmath.pi)), -1, 1e-15) 
+    end
+
+    testset "numtostr" do
+        tmath.numtostr.format.float = "%0.3f"
+        terracode
+            io.printf("value = %s\n", tmath.numtostr(1))
+            io.printf("value = %s\n", tmath.numtostr(1.999999999999))
+        end
+        tmath.numtostr.format.float = "%0.5f"
+        terracode
+            io.printf("value = %s\n", tmath.numtostr(1))
+            io.printf("value = %s\n", tmath.numtostr(1.999999999999))
+        end
     end
 
 end

--- a/test_math.t
+++ b/test_math.t
@@ -5,7 +5,7 @@
 
 import "terratest/terratest"
 
-local math = require('mathfuns')
+local tmath = require('mathfuns')
 
 local funs_single_var = {
     "sin",
@@ -36,7 +36,7 @@ local funs_single_var = {
 testenv "All single variable math functions" do
     --test correctness of output type
     for k,f in ipairs(funs_single_var) do
-        local mathfun = math[f]
+        local mathfun = tmath[f]
         testset(f) "fun " do
             terracode
                 var xfloat = mathfun([float](0))
@@ -49,25 +49,34 @@ testenv "All single variable math functions" do
 end
 
 testenv "Correctness of selected math functions" do
-    --test if result is correct
+    testset "special values" do
+        for _, T in ipairs({float, double, int8, int16, int32, int64, uint8, uint16, uint32, uint64}) do
+            test [T:zero()] == 0
+            test [T:unit()] == 1
+        end
+        test tmath.isapprox(tmath.pi, [math.pi], 1e-15) --compare with Lua's value
+        test [float:eps()] == 0x1p-23
+        test [double:eps()] == 0x1p-52
+    end
+
     testset "sqrt" do
-        test math.isapprox(math.sqrt([float](4)), 2.0f, 1e-7f) 
-        test math.isapprox(math.sqrt([double](4)), 2.0, 1e-15) 
+        test tmath.isapprox(tmath.sqrt([float](4)), 2.0f, 1e-7f) 
+        test tmath.isapprox(tmath.sqrt([double](4)), 2.0, 1e-15) 
     end
 
     testset "log" do
-        test math.isapprox(math.log([float](1)), 0, 1e-7f) 
-        test math.isapprox(math.log([double](1)), 0, 1e-15) 
+        test tmath.isapprox(tmath.log([float](1)), 0, 1e-7f) 
+        test tmath.isapprox(tmath.log([double](1)), 0, 1e-15) 
     end
 
     testset "sin" do
-        test math.isapprox(math.sin([float](math.pi)), 0, 1e-7f) 
-        test math.isapprox(math.sin([double](math.pi)), 0, 1e-15) 
+        test tmath.isapprox(tmath.sin([float](tmath.pi)), 0, 1e-7f) 
+        test tmath.isapprox(tmath.sin([double](tmath.pi)), 0, 1e-15) 
     end
 
     testset "cos" do
-        test math.isapprox(math.cos([float](math.pi)), -1, 1e-7f) 
-        test math.isapprox(math.cos([double](math.pi)), -1, 1e-15) 
+        test tmath.isapprox(tmath.cos([float](tmath.pi)), -1, 1e-7f) 
+        test tmath.isapprox(tmath.cos([double](tmath.pi)), -1, 1e-15) 
     end
 
 end

--- a/test_math.t
+++ b/test_math.t
@@ -8,6 +8,22 @@ import "terratest/terratest"
 local tmath = require('mathfuns')
 local io = terralib.includec("stdio.h")
 
+if not __silent__ then
+
+    --some printing tests
+    local format = tmath.numtostr.format[double]
+    terra main()
+        io.printf("value = %s\n", tmath.numtostr(1))
+        io.printf("value = %s\n", tmath.numtostr(1.999999999999))
+
+        format = "%0.3e"
+        io.printf("value = %s\n", tmath.numtostr(1))
+        io.printf("value = %s\n", tmath.numtostr(1.999999999999))
+    end
+    main()
+
+end
+
 local funs_single_var = {
     "sin",
     "cos",
@@ -78,19 +94,6 @@ testenv "Correctness of selected math functions" do
     testset "cos" do
         test tmath.isapprox(tmath.cos([float](tmath.pi)), -1, 1e-7f) 
         test tmath.isapprox(tmath.cos([double](tmath.pi)), -1, 1e-15) 
-    end
-
-    testset "numtostr" do
-        tmath.numtostr.format.float = "%0.3f"
-        terracode
-            io.printf("value = %s\n", tmath.numtostr(1))
-            io.printf("value = %s\n", tmath.numtostr(1.999999999999))
-        end
-        tmath.numtostr.format.float = "%0.5f"
-        terracode
-            io.printf("value = %s\n", tmath.numtostr(1))
-            io.printf("value = %s\n", tmath.numtostr(1.999999999999))
-        end
     end
 
 end

--- a/test_nfloat.t
+++ b/test_nfloat.t
@@ -6,12 +6,20 @@
 import "terratest/terratest"
 
 local nfloat = require("nfloat")
-local mathfun = require("mathfuns")
+local tmath = require("mathfuns")
 
 local suffix = {64, 128, 192, 256, 384, 512, 1024, 2048, 4096}
 for _, N in pairs(suffix) do
     testenv(N) "Float" do
         local T = nfloat.FixedFloat(N)
+        testset "constants: zero, one" do
+            local zero = T:zero()
+            local unit = T:unit()
+            local eps = T:eps()
+            test zero == 0
+            test unit == 1
+            test [T:eps()] == 0.5 * tmath.pow(T(2), -N)
+        end
         testset "from" do
             terracode
                 var asdouble = T.from(3.5)

--- a/test_nfloat.t
+++ b/test_nfloat.t
@@ -5,26 +5,9 @@
 
 import "terratest/terratest"
 
-local io = terralib.includec("stdio.h")
+local C = terralib.includec("string.h")
 local nfloat = require("nfloat")
 local tmath = require("mathfuns")
-
-if not __silent__ then
-
-    --some printing tests
-    local T = nfloat.FixedFloat(256)
-    local format = tmath.numtostr.format[T]
-    terra main()
-        io.printf("value = %s\n", tmath.numtostr(T(1)))
-        io.printf("value = %s\n", tmath.numtostr(T(1.999999999999)))
-
-        format = "%0.3f"
-        io.printf("value = %s\n", tmath.numtostr(T(1)))
-        io.printf("value = %s\n", tmath.numtostr(T(1.999999999999)))
-    end
-    main()
-
-end
 
 
 local suffix = {64, 128, 192, 256, 384, 512, 1024, 2048, 4096}
@@ -94,6 +77,22 @@ for _, N in pairs(suffix) do
                 var c: T = 1.125
             end
             test a / b == c
+        end
+
+        testset "printing" do
+            --some printing tests
+            local format = tmath.numtostr.format[T]
+            terracode
+                var s1 = tmath.numtostr(T(1))
+                var s2 = tmath.numtostr(T(1.999999999999))
+                format = "%0.3f"
+                var s3 = tmath.numtostr(T(1))
+                var s4 = tmath.numtostr(T(1.999999999999))
+            end
+            test C.strcmp(&s1[0], "1.00") == 0
+            test C.strcmp(&s2[0], "2.00") == 0
+            test C.strcmp(&s3[0], "1.000") == 0
+            test C.strcmp(&s4[0], "2.000") == 0
         end
     end
 end

--- a/test_nfloat.t
+++ b/test_nfloat.t
@@ -8,6 +8,7 @@ import "terratest/terratest"
 local nfloat = require("nfloat")
 local tmath = require("mathfuns")
 
+
 local suffix = {64, 128, 192, 256, 384, 512, 1024, 2048, 4096}
 for _, N in pairs(suffix) do
     testenv(N) "Float" do

--- a/test_nfloat.t
+++ b/test_nfloat.t
@@ -5,8 +5,26 @@
 
 import "terratest/terratest"
 
+local io = terralib.includec("stdio.h")
 local nfloat = require("nfloat")
 local tmath = require("mathfuns")
+
+if not __silent__ then
+
+    --some printing tests
+    local T = nfloat.FixedFloat(256)
+    local format = tmath.numtostr.format[T]
+    terra main()
+        io.printf("value = %s\n", tmath.numtostr(T(1)))
+        io.printf("value = %s\n", tmath.numtostr(T(1.999999999999)))
+
+        format = "%0.3f"
+        io.printf("value = %s\n", tmath.numtostr(T(1)))
+        io.printf("value = %s\n", tmath.numtostr(T(1.999999999999)))
+    end
+    main()
+
+end
 
 
 local suffix = {64, 128, 192, 256, 384, 512, 1024, 2048, 4096}

--- a/test_qr.t
+++ b/test_qr.t
@@ -32,7 +32,7 @@ local io = terralib.includec("stdio.h")
 for _, Ts in pairs({float, double, float128, float1024}) do
     for _, is_complex in pairs({false, true}) do
         local T = is_complex and complex.complex(Ts) or Ts
-        local unit = is_complex and quote in T.unit() end or quote in 0 end
+        local unit = is_complex and T:unit() or 0
         local DMat = dmatrix.DynamicMatrix(T)
         local DVec = dvector.DynamicVector(T)
         local Alloc = alloc.DefaultAllocator()


### PR DESCRIPTION
For all number types: primitives, nfloats, complex numbers:
* `T:unit()`, `T:zero()`
* `tmath.numtostr(x : T)`

For all primitive types:
* `T:eps()`

`T:unit()`, `T:zero()`, `T:eps()` are lua methods that return a terra constant variable.