### PR TITLE
refactoring of codebase with move semantics

### DIFF
--- a/boltzmann.t
+++ b/boltzmann.t
@@ -176,7 +176,7 @@ local TensorBasis = terralib.memoize(function(T)
         tb.transposed = transposed
         tb.cast = cast
 
-        tb.velocity = MonomialBasis.new(iMat.frombuffer(nv, VDIM, ptr, VDIM))
+        tb.velocity = MonomialBasis.new(__move__(iMat.frombuffer(nv, VDIM, ptr, VDIM)))
 
         return tb
     end

--- a/gauss.t
+++ b/gauss.t
@@ -364,7 +364,7 @@ terra besselJ1(alloc : Allocator, m : size_t)
     return Jk2
 end
 
-local terra legpts_nodes(alloc : Allocator, n : size_t, a : dvec)
+local terra legpts_nodes(alloc : Allocator, n : size_t, a : &dvec)
     --asymptotic expansion for the Gauss-Legendre nodes
     var vn = 1. / (n + 0.5)
     var m = a:size()
@@ -401,7 +401,7 @@ local terra legpts_nodes(alloc : Allocator, n : size_t, a : dvec)
     return nodes
 end
 
-local terra legpts_weights(alloc : Allocator, n : size_t, a : dvec)
+local terra legpts_weights(alloc : Allocator, n : size_t, a : &dvec)
     --asymptotic expansion for the Gauss-Legendre weights
     var m = a:size()
     var vn = 1. / (n + 0.5)
@@ -456,8 +456,8 @@ local terra asy(alloc : Allocator, n : size_t)
     var m = (n + 1) >> 1
     var a = bessel_zero_roots(&alloc, m)
     a:scal(1. / (n + 0.5))
-    var x = legpts_nodes(&alloc, n, a)
-    var w = legpts_weights(&alloc, n, a)
+    var x = legpts_nodes(&alloc, n, &a)
+    var w = legpts_weights(&alloc, n, &a)
     return x, w
 end
 
@@ -529,12 +529,10 @@ terra imp.legendre(alloc : Allocator, n : size_t)
             dvec.from(&alloc, (322. - 13. * tmath.sqrt(70.)) / 900., (322. + 13. * tmath.sqrt(70.)) / 900., 128. / 225., (322. + 13. * tmath.sqrt(70.)) / 900., (322. - 13. * tmath.sqrt(70.)) / 900.)
     elseif n <= 60 then
         --Newton's method with three-term recurrence
-        var x, w = rec(&alloc, n)
-        return x, w
+        return rec(alloc, n)
     else
         --use asymptotic expansions:
-        var x, w = asy(&alloc, n)
-        return x, w
+        return asy(&alloc, n)
     end
 end
 

--- a/gauss.t
+++ b/gauss.t
@@ -175,7 +175,7 @@ local terra hermite_initialguess(alloc : Allocator, n : size_t)
         x:push(0.0)
     end
     -- return as a dvector
-    return [dvec](x:__move())
+    return [dvec](x)
 end
 
 local terra hermpoly_rec(x0 : double, n : size_t)

--- a/smartmem.t
+++ b/smartmem.t
@@ -206,7 +206,7 @@ local SmartBlock = terralib.memoize(function(T, options)
             --case when to.eltype is a managed type
             if ismanaged{type=to.traits.eltype, method="__init"} then
                 return quote
-                    var tmp = exp
+                    var tmp = __move__(exp)
                     --debug check if sizes are compatible, that is, is the
                     --remainder zero after integer division
                     err.assert(tmp:size_in_bytes() % [to.elsize]  == 0)
@@ -223,7 +223,7 @@ local SmartBlock = terralib.memoize(function(T, options)
             --simple case when to.eltype is not managed
             else
                 return quote
-                    var tmp = exp
+                    var tmp = __move__(exp)
                     --debug check if sizes are compatible, that is, is the
                     --remainder zero after integer division
                     err.assert(tmp:size_in_bytes() % [to.elsize]  == 0)

--- a/stack.t
+++ b/stack.t
@@ -160,6 +160,9 @@ local DynamicStack = terralib.memoize(function(T)
         self.size = 0
     end
 
+    terralib.ext.addmissing.__move(stack)
+    stack.methods.__copy = stack.methods.__move
+
     --sanity check
     assert(concepts.DStack(stack), "Stack type does not satisfy the DStack concepts.")
 

--- a/stack.t
+++ b/stack.t
@@ -160,17 +160,6 @@ local DynamicStack = terralib.memoize(function(T)
         self.size = 0
     end
 
-    --behavior w.r.t memory allocation, etc
-    terralib.ext.addmissing.__move(stack)
-    terralib.ext.addmissing.__forward(stack)
-
-    --specialized copy-assignment - the resource is always moved from
-    stack.methods.__copy = terra(from : &stack, to : &stack)
-        to.data = from.data:__move()
-        to.size = from.size
-        from:__init()
-    end
-
     --sanity check
     assert(concepts.DStack(stack), "Stack type does not satisfy the DStack concepts.")
 

--- a/test_alloc.t
+++ b/test_alloc.t
@@ -7,10 +7,7 @@ local io = terralib.includec("stdio.h")
 import "terratest/terratest"
 
 local alloc = require("alloc")
-
-local size_t = uint64
-local block = alloc.block
-local Allocator = alloc.Allocator
+local DefaultAllocator = alloc.DefaultAllocator()
 
 for _, alignment in ipairs{0, 64} do
 
@@ -205,8 +202,6 @@ end
 
 import "terraform"
 
-local DefaultAllocator = alloc.DefaultAllocator()
-
 testenv "SmartObject" do
 
     local struct myobj{
@@ -250,7 +245,6 @@ testenv "SmartObject" do
 
 end
 
-
 testenv "singly linked list - that is a cycle" do
 
 	local Allocator = alloc.Allocator
@@ -269,6 +263,10 @@ testenv "singly linked list - that is a cycle" do
             end
         end
     end)
+
+    local terra get_smrt_s_node_dtor_counter()
+        return smrt_s_node_dtor_counter
+    end
 
     smrt_s_node.metamethods.__entrymissing = macro(function(entryname, self)
         return `self.ptr.[entryname]
@@ -347,7 +345,6 @@ testenv "singly linked list - that is a cycle" do
         test smrt_s_node_dtor_counter==4
     end
 end
-
 
 testenv "doubly linked list - that is a cycle" do
 

--- a/test_dvector.t
+++ b/test_dvector.t
@@ -16,7 +16,6 @@ local DefaultAllocator =  Alloc.DefaultAllocator()
 local float128 = Nfloat.FixedFloat(128)
 local float1024 = Nfloat.FixedFloat(1024)
 
-
 for _, is_complex in pairs({false, true}) do
 for _, S in pairs({int, uint, int64, uint64, float, double, float128, float1024}) do
     local T
@@ -118,7 +117,7 @@ for _, S in pairs({int, uint, int64, uint64, float, double, float128, float1024}
                 var s = dstack.new(&alloc, 3)
                 s:push(1.0)
                 s:push(2.0)
-                var v : dvector = s:__move()
+                var v = [dvector](s)
             end
             test s.data:isempty()
             test v.data:owns_resource()

--- a/test_gauss.t
+++ b/test_gauss.t
@@ -32,7 +32,7 @@ tmath.isapprox:adddefinition(terra(v : dvec, w : dvec, atol : double)
     return false
 end)
 
-testenv(skip) "gauss Legendre quadrature" do
+testenv "gauss Legendre quadrature" do
 
     terracode
         var alloc : DefaultAllocator
@@ -73,7 +73,7 @@ testenv(skip) "gauss Legendre quadrature" do
 
 end
 
-testenv(skip) "gauss Chebyshev quadrature" do
+testenv "gauss Chebyshev quadrature" do
 
     local poly2 = poly.Polynomial(double, 3)
     local poly3 = poly.Polynomial(double, 4)
@@ -145,7 +145,7 @@ testenv(skip) "gauss Chebyshev quadrature" do
     end
 end
 
-testenv(skip) "gauss Jacobi quadrature" do
+testenv "gauss Jacobi quadrature" do
 
     terracode
         var alloc : DefaultAllocator
@@ -321,7 +321,7 @@ interval.metamethods.__entrymissing = macro(function(entryname, self)
     end
 end)
 
-testenv(skip) "API" do
+testenv "API" do
 
     terracode
         var alloc : DefaultAllocator

--- a/test_stack.t
+++ b/test_stack.t
@@ -9,6 +9,7 @@ local stack = require("stack")
 
 import "terratest/terratest"
 
+
 testenv "DynamicStack" do
 
     local T = double
@@ -120,7 +121,6 @@ testenv "DynamicStack" do
             var p : &smrtblock
             do
                 var v = stack.new(&alloc, 4)
-                --the following raises an issue in terralib
                 p = &v.data
             end --v:__dtor() is called here by the compiler
         end

--- a/thread.t
+++ b/thread.t
@@ -80,12 +80,11 @@ local thrd = (
         }
     )
 )
-local ffi = require("ffi")
-local OS = ffi.os
-if OS == "Linux" then
+
+local uname = io.popen("uname", "r"):read("*a")
+if uname == "Linux\n" then
     terralib.linklibrary("libpthread.so.0")
-elseif OS == "Darwin" then
-    error("Rene, your turn!")
+elseif uname == "Darwin\n" then
     terralib.linklibrary("libpthread.dylib")
 else
     error("Unsupported platform for multithreading")

--- a/thread.t
+++ b/thread.t
@@ -576,8 +576,8 @@ threadpool.staticmethods.new = (
         tp.done = false
         tp.threads = alloc:new(nthreads, sizeof(thread))
         tp.joiner = join_threads {tp.threads}
-        -- The point of no return. From this point on, we running the program
-        -- concurrently.
+        -- The point of no return. From this point on, we are running the 
+        -- program concurrently.
         for i = 0, nthreads do
             tp.threads(i) = (
                 thread.new(


### PR DESCRIPTION
A move can now be forced in an assignment or when passing by value to a function using the `__move__(x)` compiler directive

updated among others the following files to use the new move semantics implemented in terralib. 
* dvector
* dstack
* boltzmann.t